### PR TITLE
Improve UX a tad for mobile

### DIFF
--- a/client/src/JoinGame/Categories.css
+++ b/client/src/JoinGame/Categories.css
@@ -1,10 +1,11 @@
 @import "../common/Styles.css";
 
 .category-dropdown {
-  width: 30%;
-  height: 137px;
   display: flex;
+  height: 137px;
   margin: 20px auto;
+  max-width: 600px;
+  width: auto;
 }
 
 .select {

--- a/client/src/JoinGame/index.js
+++ b/client/src/JoinGame/index.js
@@ -83,24 +83,17 @@ class JoinGame extends Component {
             <div className="join-game-section">
               {!props.name && (
                 <form className="join-game-form" id="join-game-form">
-                  <label
-                    className={`name-label vertical-section ${!canUseName &&
-                      "validation-failed"}`}
-                  >
-                    {!canUseName && (
-                      <>
-                        <span>Sorry, that name’s taken.</span>
-                        <span>Choose another?</span>
-                      </>
-                    )}
-                    <input
-                      className="name-field"
-                      type="text"
-                      value={state.name}
-                      onChange={this.updateName}
-                      placeholder="Hello there! What's your name?"
-                    />
-                  </label>
+                  <input
+                    aria-label={
+                      canUseName ? "input name" : "invalid name, already taken."
+                    }
+                    id="name-field"
+                    className="name-field"
+                    type="text"
+                    value={state.name}
+                    onChange={this.updateName}
+                    placeholder="Name, please!"
+                  />
                   <AsyncButton
                     disabled={
                       state.name.length === 0 || props.isWaiting || !canUseName
@@ -112,7 +105,7 @@ class JoinGame extends Component {
                     size="small"
                     style={{ width: "100%" }}
                   >
-                    Join
+                    {!canUseName ? "Sorry, that name’s taken." : "Join"}
                   </AsyncButton>
                 </form>
               )}

--- a/client/src/JoinGame/styles.css
+++ b/client/src/JoinGame/styles.css
@@ -60,14 +60,6 @@
   align-items: center;
 }
 
-.name-label {
-  width: 100%;
-  font-size: 2em;
-  text-transform: uppercase;
-  font-weight: 600;
-  margin: 20px 0;
-}
-
 .name-label.validation-failed {
   color: var(--orange);
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/l0MYLoXAw7JSyHiZG/giphy.gif)

Fixes https://github.com/efhjones/zap-phrase/issues/21

### Before

Mobile UX was pretty crummy

![](https://cdn.zapier.com/storage/photos/0a051ce5075d2396ea257fad94dcdd4b_2.png)

### After

It's marginally better

![](https://cdn.zapier.com/storage/photos/5ba4886413b19b7c37e66fcd7ea9f898_2.png)

I also moved the taken name message into the button

![](https://cdn.zapier.com/storage/photos/b8f992cc895bce7dbb6b847035651178.png)

So, there's that.