### PR TITLE
Make sure next phrase doesn't show after clicking next

### DIFF
--- a/client/src/Game/index.js
+++ b/client/src/Game/index.js
@@ -20,6 +20,7 @@ class Game extends Component {
     this.state = {
       remainingPhrases: shuffledPhrases,
       currentPhrase: shuffledPhrases[0],
+      shouldShowCurrentPhrase: true,
       winner: null
     };
 
@@ -31,6 +32,12 @@ class Game extends Component {
         }
       }
     );
+
+    this.props.socket.on("player changed", ({ gameId }) => {
+      if (gameId === this.props.gameId) {
+        this.setState({ shouldShowCurrentPhrase: true });
+      }
+    });
 
     this.props.socket.on("winner declared", ({ winner, gameId }) => {
       if (this.props.gameId === gameId) {
@@ -86,8 +93,11 @@ class Game extends Component {
     }
   };
 
-  onClickNext = e => {
+  onClickNext = async e => {
     e.persist();
+    await this.setState({
+      shouldShowCurrentPhrase: false
+    });
     this.setNextPhrase();
     this.setNextPlayer();
   };
@@ -124,7 +134,7 @@ class Game extends Component {
               {!isCurrentPlayer && !shouldGuess && <Shh />}
             </span>
           </section>
-          {isCurrentPlayer && (
+          {isCurrentPlayer && state.shouldShowCurrentPhrase && (
             <>
               <section className="vertical-section">
                 <span className="phrase">{state.currentPhrase}</span>


### PR DESCRIPTION
This is a hacky fix for https://github.com/efhjones/zap-phrase/issues/23

The problem is that we have a race condition -- will the socket respond with the next player first, or the next phrase?

This PR sidesteps the actual issue by making sure the phrase is hidden before it kicks off the request to choose the next player.

Maybe someday I'll actually clean up this code and fix it properly.